### PR TITLE
Switch markdownlint to Node.js to fix #12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         additional_dependencies:
           - types-PyYAML==5.4.10
           - types-setuptools==57.4.0
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.5
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.29.0
     hooks:
       - id: markdownlint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD024 -->
+
 # Changelog
 
 All notable changes to `aa-tools` will be documented in this file.
@@ -22,7 +24,6 @@ and this project adheres to
 
 ## [0.1.0] - 2021-10-12
 
-<!-- markdownlint-disable MD024 -->
 ### Added
 
 - CDS Area module

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently under development
 
 To setup the development environment, please install all packages from `requirements/requirements-dev.txt`:
 
-```
+```shell
 pip install -r requirements/requirements-dev.txt
 ```
 
@@ -28,7 +28,7 @@ Thereafter all commits will be checked against black and flake8 guidelines
 
 To check if your changes pass pre-commit without committing, run:
 
-```
+```shell
 pre-commit run --all-files
 ```
 
@@ -36,7 +36,7 @@ pre-commit run --all-files
 
 To install, execute:
 
-```
+```shell
 python setup.py develop
 ```
 
@@ -44,7 +44,7 @@ python setup.py develop
 
 To run the tests and view coverage, execute:
 
-```
+```shell
 pytest --cov=aatoolbox
 ```
 
@@ -54,7 +54,7 @@ Note that you first need to install the aatoolbox package.
 
 To build the docs, execute:
 
-```
+```shell
 python setup.py build_sphinx
 ```
 


### PR DESCRIPTION
After a quick investigation again, I finally found the [Node.js markdownlint pre-commit](https://github.com/igorshubovych/markdownlint-cli), which allows full file ignoring.