### PR TITLE
ignore dsstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+#Mac DSStore
+.DS_Store


### PR DESCRIPTION
Ignore Mac specific DS_Store files

Thought this is not worth mentioning in the changelog but correct me if I am wrong. 