### PR TITLE
Remove doc generation hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,15 +40,6 @@ repos:
     rev: v0.29.0
     hooks:
       - id: markdownlint
-  - repo: https://github.com/thclark/pre-commit-sphinx
-    rev: 0.0.1
-    hooks:
-      - id: build-docs
-        additional_dependencies:
-          - sphinxcontrib-apidoc
-        args: ['--cache-dir', 'docs/build/doctrees', '--html-dir',
-               'docs/build/html', '--source-dir', 'docs/source']
-        language_version: python3
   - repo: https://github.com/jazzband/pip-tools
     rev: 6.3.0
     hooks:
@@ -59,9 +50,14 @@ repos:
                -o, requirements/requirements.txt]
       - id: pip-compile
         name: pip-compile requirements-dev.txt
-        files: requirements/(dev.in|tests.in|requirements.txt)
+        files: requirements/(dev.in|docs.in|tests.in|requirements.txt)
         args: [requirements/dev.in, -q, --no-header,
                -o, requirements/requirements-dev.txt]
+      - id: pip-compile
+        name: pip-compile requirements-docs.txt
+        files: requirements/docs.in
+        args: [ requirements/docs.in, -q, --no-header,
+                -o, requirements/requirements-docs.txt ]
       - id: pip-compile
         name: pip-compile requirements-tests.txt
         files: requirements/tests.in

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently under development
 
 ### Environment
 
-To setup the development environment, please install all packages
+To set up the development environment, please install all packages
 from `requirements/requirements-dev.txt`:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ pytest --cov=aatoolbox
 
 All public modules, classes and methods should be documented with
 [numpy-style](https://numpydoc.readthedocs.io/en/latest/format.html)
-docstrings, which are rendered into HTML using a pre-commit hook.
+docstrings, which can be rendered into HTML using the following command:
+
+```shell
+sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
+```
+
 To view the docs, open up `docs/build/html/index.html` in your browser.
 
 ### pre-commit
@@ -68,5 +73,12 @@ For adding packages for development, documentation, or tests,
 add them to the relevant `.in` file in the `requirements` directory.
 When you modify any of these lists, please try to keep them alphabetical!
 Any changes to the `requirements*.txt` files will be generated with `pre-commit`.
+
+To run this without commiting, execute:
+
+```shell
+pre-commit run pip-compile --all-files
+```
+
 For other functionality such as updating specific package versions, refer to the
 `pip-tools` documentation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Welcome to aatoolbox's documentation!
 =====================================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 6
    :caption: Contents:
 
    modules

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,3 +1,4 @@
+-r docs.in
 -r requirements.txt
 -r tests.in
 pip-tools

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+sphinxcontrib-apidoc

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,6 +2,8 @@ affine==2.3.0
     # via
     #   -r requirements/requirements.txt
     #   rasterio
+alabaster==0.7.12
+    # via sphinx
 appdirs==1.4.4
     # via
     #   -r requirements/requirements.txt
@@ -14,6 +16,8 @@ attrs==21.2.0
     #   pytest
     #   rasterio
     #   requests-cache
+babel==2.9.1
+    # via sphinx
 backports.entry-points-selectable==1.1.0
     # via virtualenv
 basicauth==0.4.1
@@ -110,6 +114,10 @@ docopt==0.6.2
     #   -r requirements/requirements.txt
     #   ckanapi
     #   num2words
+docutils==0.17.1
+    # via
+    #   sphinx
+    #   sphinx-rtd-theme
 email-validator==1.1.3
     # via
     #   -r requirements/requirements.txt
@@ -159,12 +167,16 @@ ijson==3.1.4
     # via
     #   -r requirements/requirements.txt
     #   tabulator
+imagesize==1.3.0
+    # via sphinx
 inflect==5.3.0
     # via
     #   -r requirements/requirements.txt
     #   quantulum3
 iniconfig==1.1.1
     # via pytest
+jinja2==3.0.3
+    # via sphinx
 jmespath==0.10.0
     # via
     #   -r requirements/requirements.txt
@@ -190,6 +202,8 @@ lxml==4.6.3
     # via
     #   -r requirements/requirements.txt
     #   exchangerates
+markupsafe==2.0.1
+    # via jinja2
 munch==2.5.0
     # via
     #   -r requirements/requirements.txt
@@ -220,11 +234,14 @@ packaging==21.2
     #   -r requirements/requirements.txt
     #   pytest
     #   rioxarray
+    #   sphinx
 pandas==1.3.3
     # via
     #   -r requirements/requirements.txt
     #   geopandas
     #   xarray
+pbr==5.7.0
+    # via sphinxcontrib-apidoc
 pep517==0.11.0
     # via pip-tools
 pip-tools==6.3.1
@@ -253,6 +270,8 @@ pycparser==2.20
     #   cffi
 pydantic==1.8.2
     # via -r requirements/requirements.txt
+pygments==2.10.0
+    # via sphinx
 pyopenssl==21.0.0
     # via
     #   -r requirements/requirements.txt
@@ -296,6 +315,7 @@ python-slugify==5.0.2
 pytz==2021.3
     # via
     #   -r requirements/requirements.txt
+    #   babel
     #   pandas
 pyyaml==6.0
     # via
@@ -321,6 +341,7 @@ requests==2.26.0
     #   libhxl
     #   requests-cache
     #   requests-file
+    #   sphinx
     #   tabulator
 requests-cache==0.8.1
     # via
@@ -365,6 +386,8 @@ six==1.16.0
     #   tabulator
     #   url-normalize
     #   virtualenv
+snowballstemmer==2.2.0
+    # via sphinx
 snuggs==1.4.7
     # via
     #   -r requirements/requirements.txt
@@ -373,6 +396,27 @@ soupsieve==2.2.1
     # via
     #   -r requirements/requirements.txt
     #   beautifulsoup4
+sphinx==4.3.0
+    # via
+    #   -r requirements/docs.in
+    #   sphinx-rtd-theme
+    #   sphinxcontrib-apidoc
+sphinx-rtd-theme==1.0.0
+    # via -r requirements/docs.in
+sphinxcontrib-apidoc==0.3.0
+    # via -r requirements/docs.in
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
+    # via sphinx
 sqlalchemy==1.4.26
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -263,7 +263,6 @@ pyparsing==2.4.7
     #   -r requirements/requirements.txt
     #   packaging
     #   snuggs
-    # via packaging
 pyphonetics==0.5.3
     # via
     #   -r requirements/requirements.txt
@@ -302,14 +301,14 @@ pyyaml==6.0
     # via
     #   -r requirements/requirements.txt
     #   pre-commit
-rasterio==1.2.10
-    # via
-    #   -r requirements/requirements.txt
-    #   rioxarray
 quantulum3==0.7.9
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-api
+rasterio==1.2.10
+    # via
+    #   -r requirements/requirements.txt
+    #   rioxarray
 ratelimit==2.2.1
     # via
     #   -r requirements/requirements.txt
@@ -424,15 +423,14 @@ webencodings==0.5.1
     #   -r requirements/requirements.txt
     #   html5lib
 wheel==0.37.0
-    # via pip-tools
-xarray==0.20.1
-    # via
-    #   -r requirements/requirements.txt
-    #   rioxarray
     # via
     #   -r requirements/requirements.txt
     #   libhxl
     #   pip-tools
+xarray==0.20.1
+    # via
+    #   -r requirements/requirements.txt
+    #   rioxarray
 xlrd==2.0.1
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -1,0 +1,60 @@
+alabaster==0.7.12
+    # via sphinx
+babel==2.9.1
+    # via sphinx
+certifi==2021.10.8
+    # via requests
+charset-normalizer==2.0.7
+    # via requests
+docutils==0.17.1
+    # via
+    #   sphinx
+    #   sphinx-rtd-theme
+idna==3.3
+    # via requests
+imagesize==1.3.0
+    # via sphinx
+jinja2==3.0.3
+    # via sphinx
+markupsafe==2.0.1
+    # via jinja2
+packaging==21.2
+    # via sphinx
+pbr==5.7.0
+    # via sphinxcontrib-apidoc
+pygments==2.10.0
+    # via sphinx
+pyparsing==2.4.7
+    # via packaging
+pytz==2021.3
+    # via babel
+requests==2.26.0
+    # via sphinx
+snowballstemmer==2.2.0
+    # via sphinx
+sphinx==4.3.0
+    # via
+    #   -r requirements/docs.in
+    #   sphinx-rtd-theme
+    #   sphinxcontrib-apidoc
+sphinx-rtd-theme==1.0.0
+    # via -r requirements/docs.in
+sphinxcontrib-apidoc==0.3.0
+    # via -r requirements/docs.in
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==2.0.0
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.5
+    # via sphinx
+urllib3==1.26.7
+    # via requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -51,7 +51,6 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-    # via fiona
 colorlog==6.5.0
     # via hdx-python-utilities
 cryptography==35.0.0
@@ -165,7 +164,6 @@ python-slugify==5.0.2
     # via ckanapi
 pytz==2021.3
     # via pandas
-
 pyyaml==6.0
     # via aa-toolbox (setup.cfg)
 quantulum3==0.7.9
@@ -208,6 +206,9 @@ six==1.16.0
     #   munch
     #   pyopenssl
     #   python-dateutil
+    #   requests-file
+    #   tabulator
+    #   url-normalize
 snuggs==1.4.7
     # via rasterio
 soupsieve==2.2.1
@@ -240,10 +241,7 @@ wheel==0.37.0
 xarray==0.20.1
     # via
     #   aa-toolbox (setup.cfg)
-    #   requests-file
     #   rioxarray
-    #   tabulator
-    #   url-normalize
 xlrd==2.0.1
     # via tabulator
 xlrd3==1.1.0


### PR DESCRIPTION
Closes #34. 

The pre-commit hook to generate the docs was not really working -- the actual docstrings were not showing up. I couldn't really figure out why; as far as I can tell the hook is running the following command:
```
sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
```
which does work on its own.

At any rate it's not crucial to have as a hook, since none of the changes it makes are actually committed; it was more for user convenience. For now, the user can just run the command by hand. I've added back the docs requirements file to permit this. 

Auto building will be addressed in #4. 