### PR TITLE
ecmwf: add start time coord

### DIFF
--- a/src/aatoolbox/datasources/ecmwf/api_seas5_monthly.py
+++ b/src/aatoolbox/datasources/ecmwf/api_seas5_monthly.py
@@ -280,9 +280,21 @@ class EcmwfApi(DataSource):
             + 12 * (ds_month.time.dt.year - pub_date.dt.year)
             + 1
         )
+        # start_forecast_time = ds_month.time.values
         ds_month = (
             ds_month.rename({"time": "step"})
-            .assign_coords({"time": pub_date, "step": steps.values})
+            .assign_coords(
+                {
+                    "time": pub_date,
+                    "step": steps.values,
+                    # just renaming time to start_forecast_time doesn't
+                    # work cause want it to be dependent on the step
+                    # parameter instead of having its own dimension
+                    # TODO: now getting messed up when merging with the
+                    # realtime data. So find solution for that.
+                    # "start_forecast_time":("step",start_forecast_time)
+                }
+            )
             .expand_dims("time")
         )
         return ds_month


### PR DESCRIPTION
Based on our discussion [here](https://github.com/OCHA-DAP/pa-anticipatory-action/pull/248) and #40, I attempted to add an additonal coord `start_forecast_time` which indicates the start date at which the forecast is valid and is dependent on `time` and `step`. It almost works but due to only having one date for the realtime dataset it doesn't merge nicely. 

I got frustrated and couldn't find a solution, so wondering if you know one? And if it is worth making it work when one of the datasets has only one entry, or that we should just assume there are several.. 