### PR TITLE
bugfix: duplicate test PyPI versions

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,5 +1,9 @@
 name: Build and publish to PyPI and TestPyPI
-on: push
+on:
+  push:
+    branches:
+      - main
+      - develop
 jobs:
   build-and-publish:
     name: Build and publish to PyPI and TestPyPI

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,11 +1,11 @@
-name: Build and publish to PyPI and TestPyPI
+name: PyPI
 on:
   push:
     branches:
       - main
       - develop
 jobs:
-  build:
+  build-and-publish:
     name: Build and publish to PyPI and TestPyPI
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -5,7 +5,7 @@ on:
       - main
       - develop
 jobs:
-  build-and-publish:
+  build:
     name: Build and publish to PyPI and TestPyPI
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/run-python-tests.yaml
+++ b/.github/workflows/run-python-tests.yaml
@@ -1,7 +1,7 @@
-name: Run unit tests
+name: tests
 on: push
 jobs:
-  build:
+  build-and-test:
     name: Run unit tests
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/run-python-tests.yaml
+++ b/.github/workflows/run-python-tests.yaml
@@ -1,7 +1,7 @@
 name: Run unit tests
 on: push
 jobs:
-  build-and-test:
+  build:
     name: Run unit tests
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aa-toolbox: Toolbox for anticipatory action
 
 [![license](https://img.shields.io/github/license/OCHA-DAP/pa-aa-toolbox.svg)](https://github.com/OCHA-DAP/pa-aa-toolbx/blob/main/LICENSE)
-[![Build Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/build/badge.svg)](https://github.com/OCHA-DAP/pa-aa-toolbox/actions?query=workflow%3Abuild-and-publish)
+[![Build Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/build/badge.svg)](https://github.com/OCHA-DAP/pa-aa-toolbox/actions?query=workflow%3Abuild)
 [![Coverage Status](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox/branch/main/graph/badge.svg?token=JpWZc5js4y)](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # aa-toolbox: Toolbox for anticipatory action
 
 [![license](https://img.shields.io/github/license/OCHA-DAP/pa-aa-toolbox.svg)](https://github.com/OCHA-DAP/pa-aa-toolbx/blob/main/LICENSE)
-[![Build Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/build/badge.svg)](https://github.com/OCHA-DAP/hdx-python-api/actions?query=workflow%3Abuild)
-[![Coverage Status](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox/branch/main/graph/badge.svg?token=JpWZc5js4y)](https://codecov.io/gh/OCHA-DAP/hdx-python-api)
+[![Build Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/build/badge.svg)](https://github.com/OCHA-DAP/pa-aa-toolbox/actions?query=workflow%3Abuild-and-publish)
+[![Coverage Status](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox/branch/main/graph/badge.svg?token=JpWZc5js4y)](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # aa-toolbox: Toolbox for anticipatory action
 
 [![license](https://img.shields.io/github/license/OCHA-DAP/pa-aa-toolbox.svg)](https://github.com/OCHA-DAP/pa-aa-toolbx/blob/main/LICENSE)
-[![Build Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/build/badge.svg)](https://github.com/OCHA-DAP/pa-aa-toolbox/actions?query=workflow%3Abuild)
+[![Test Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/tests/badge.svg)](https://github.com/OCHA-DAP/pa-aa-toolbox/actions?query=workflow%3Atests)
+[![PyPI Status](https://github.com/OCHA-DAP/pa-aa-toolbox/workflows/PyPI/badge.svg)](https://github.com/OCHA-DAP/pa-aa-toolbox/actions?query=workflow%3APyPI)
 [![Coverage Status](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox/branch/main/graph/badge.svg?token=JpWZc5js4y)](https://codecov.io/gh/OCHA-DAP/pa-aa-toolbox)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)


### PR DESCRIPTION
`setuptools_scm` uses the distance from the tag to auto generate the version number. As I feared, the distance does not take into account parallel branches, so you do get some overlap in version numbers if you version every commit. Instead, I propose to only publish to Test PyPI for any merges to `main` or `develop`. 