### PR TITLE
Hotfix: Publish on PyPI when tagged

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,6 +1,12 @@
 name: PyPI
 on:
-  push
+  push:
+    branches:
+      - main
+      - release
+      - develop
+    tags:
+      - '*'
 jobs:
   build-and-publish:
     name: Build and publish to PyPI and TestPyPI
@@ -20,7 +26,6 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/ .
     - name: Publish to Test PyPI
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' || github.ref == 'refs/heads/develop'
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,10 +1,6 @@
 name: PyPI
 on:
-  push:
-    branches:
-      - main
-      - release
-      - develop
+  push
 jobs:
   build-and-publish:
     name: Build and publish to PyPI and TestPyPI
@@ -24,6 +20,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/ .
     - name: Publish to Test PyPI
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' || github.ref == 'refs/heads/develop'
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2022-01-06
+
+### Fixed
+
+- GitHub action to publish on PyPI when tagged was not running
+
 ## [0.3.0] - 2022-01-06
 
 ### Added


### PR DESCRIPTION
All PyPI publishing was limited to when pushing on three branches, which broke publishing to PyPI when main was tagged.

Taking inspiration from [this discussion](https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/29), hope it works.