### PR TITLE
Fix HDX server and COD URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - GitHub action to publish on PyPI should not be invoked for pushes to main
   (using tags instead)
+- HDX API now uses "prod" server
+- COD AB dataset URLs on HDX are standardized
 
 ## [0.3.1] - 2022-01-06
 

--- a/src/aatoolbox/config/countries/bfa.yaml
+++ b/src/aatoolbox/config/countries/bfa.yaml
@@ -1,6 +1,5 @@
 iso3: bfa
 codab:
-  hdx_address: burkina-faso-administrative-boundaries
   hdx_dataset_name: bfa_adm_igb_20200323_SHP.zip
   layer_base_name: bfa_admbnda_adm{admin_level}_igb_20200323.shp
   admin_level_max: 3

--- a/src/aatoolbox/config/countries/bgd.yaml
+++ b/src/aatoolbox/config/countries/bgd.yaml
@@ -1,6 +1,5 @@
 iso3: bgd
 codab:
-  hdx_address: administrative-boundaries-of-bangladesh-as-of-2015
   hdx_dataset_name: bgd_adm_bbs_20201113_SHP.zip
   layer_base_name: bgd_adm_bbs_20201113_SHP/bgd_admbnda_adm{admin_level}_bbs_20201113.shp
   admin_level_max: 4

--- a/src/aatoolbox/config/countries/cod.yaml
+++ b/src/aatoolbox/config/countries/cod.yaml
@@ -1,9 +1,8 @@
 iso3: cod
 codab:
-  hdx_address: cod-ab-cod
   hdx_dataset_name: cod_admbnda_rgc_itos_20190911_SHP.zip
   layer_base_name: cod_admbnda_adm{admin_level}_rgc_itos_20190911.shp
   admin_level_max: 1
-  #this is the name of the adm2 layer
+  # this is the name of the adm2 layer
   custom_layer_names:
     - cod_admbnda_adm2_rgc_20190911.shp

--- a/src/aatoolbox/config/countries/eth.yaml
+++ b/src/aatoolbox/config/countries/eth.yaml
@@ -1,6 +1,5 @@
 iso3: eth
 codab:
-  hdx_address: ethiopia-cod-ab
   hdx_dataset_name: ETH Administrative Divisions Shapefiles.zip
   layer_base_name: eth_admbnda_adm{admin_level}_csa_bofed_20201008.shp
   admin_level_max: 2

--- a/src/aatoolbox/config/countries/mwi.yaml
+++ b/src/aatoolbox/config/countries/mwi.yaml
@@ -1,6 +1,5 @@
 iso3: mwi
 codab:
-  hdx_address: malawi-administrative-level-0-3-boundaries
   hdx_dataset_name: mwi_adm_nso_20181016_SHP.zip
   layer_base_name: mwi_admbnda_adm{admin_level}_nso_20181016.shp
   admin_level_max: 3

--- a/src/aatoolbox/config/countries/npl.yaml
+++ b/src/aatoolbox/config/countries/npl.yaml
@@ -1,6 +1,5 @@
 iso3: npl
 codab:
-  hdx_address: administrative-bounadries-of-nepal
   hdx_dataset_name: npl_admbnda_nd_20201117_SHP.zip
   layer_base_name: npl_admbnda_adm{admin_level}_nd_20201117.shp
   admin_level_max: 2

--- a/src/aatoolbox/config/countryconfig.py
+++ b/src/aatoolbox/config/countryconfig.py
@@ -12,9 +12,6 @@ class CodABConfig(BaseModel):
 
     Parameters
     ----------
-    hdx_address: str
-        The page where the COD AB dataset resides on on HDX. Can be found
-        by taking the portion of the url after ``data.humdata.org/dataset/``
     hdx_dataset_name: str
         COD AB dataset name on HDX. Can be found by taking the filename as it
         appears on the dataset page.
@@ -28,7 +25,6 @@ class CodABConfig(BaseModel):
         Any additional layer names that don't fit into the admin level paradigm
     """
 
-    hdx_address: str
     hdx_dataset_name: str
     layer_base_name: str  # TODO: validate that it has {admin_level}
     admin_level_max: int

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -70,7 +70,7 @@ class CodAB(DataSource):
         """
         return _download(
             filepath=self._raw_filepath,
-            hdx_address=self._country_config.codab.hdx_address,
+            hdx_address=f"cod-ab-{self._country_config.iso3}",
             hdx_dataset_name=self._country_config.codab.hdx_dataset_name,
             clobber=clobber,
         )

--- a/src/aatoolbox/utils/hdx_api.py
+++ b/src/aatoolbox/utils/hdx_api.py
@@ -10,7 +10,9 @@ from hdx.data.dataset import Dataset
 USER_AGENT = "aa-toolbox"
 
 logger = logging.getLogger(__name__)
-Configuration.create(user_agent=USER_AGENT, hdx_read_only=True)
+Configuration.create(
+    hdx_site="prod", user_agent=USER_AGENT, hdx_read_only=True
+)
 
 
 def load_dataset_from_hdx(

--- a/tests/datasources/fake_config.yaml
+++ b/tests/datasources/fake_config.yaml
@@ -1,6 +1,5 @@
 iso3: abc
 codab:
-  hdx_address: fake_hdx_address
   hdx_dataset_name: fake_hdx_dataset_name
   layer_base_name: fake_layer_base_name_level{admin_level}
   admin_level_max: 2

--- a/tests/datasources/test_codab.py
+++ b/tests/datasources/test_codab.py
@@ -30,7 +30,7 @@ def test_codab_download(mock_country_config, downloader):
     codab = CodAB(country_config=mock_country_config)
     codab.download()
     downloader.assert_called_with(
-        hdx_address=mock_country_config.codab.hdx_address,
+        hdx_address=f"cod-ab-{ISO3}",
         hdx_dataset_name=mock_country_config.codab.hdx_dataset_name,
         output_filepath=Path(FAKE_AA_DATA_DIR)
         / f"public/raw/{ISO3}/{MODULE_BASENAME}/"


### PR DESCRIPTION
Resolves #65 (standardizing COD URLs).

Also fixed a bug where the production server was not used with HDX API, which led to missing datasets. 