### PR TITLE
HDX download bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to
 
 - GitHub action to publish on PyPI should not be invoked for pushes to main
   (using tags instead)
-- HDX API now uses "prod" server
+- HDX API now uses "prod" server, and version >= 5.5.8 to avoid download error
 - COD AB dataset URLs on HDX are standardized
 
 ## [0.3.1] - 2022-01-06

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,5 @@
--r docs.in
 -r requirements.txt
--r tests.in
+-r requirements-docs.txt
+-r requirements-tests.txt
 pip-tools
 pre-commit

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -3,13 +3,16 @@ affine==2.3.0
     #   -r requirements/requirements.txt
     #   rasterio
 alabaster==0.7.12
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 appdirs==1.4.4
     # via
     #   -r requirements/requirements.txt
     #   requests-cache
 attrs==21.2.0
     # via
+    #   -r requirements/requirements-tests.txt
     #   -r requirements/requirements.txt
     #   cattrs
     #   fiona
@@ -17,9 +20,13 @@ attrs==21.2.0
     #   rasterio
     #   requests-cache
 babel==2.9.1
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 backports.entry-points-selectable==1.1.1
-    # via virtualenv
+    # via
+    #   -r requirements/requirements-tests.txt
+    #   virtualenv
 basicauth==0.4.1
     # via
     #   -r requirements/requirements.txt
@@ -47,6 +54,7 @@ cchardet==2.1.7
     #   tabulator
 certifi==2021.10.8
     # via
+    #   -r requirements/requirements-docs.txt
     #   -r requirements/requirements.txt
     #   fiona
     #   pyproj
@@ -60,7 +68,7 @@ cfgv==3.3.1
     # via pre-commit
 cftime==1.5.2
     # via
-    #   -r requirements/tests.in
+    #   -r requirements/requirements-tests.txt
     #   netcdf4
 chardet==4.0.0
     # via
@@ -68,6 +76,7 @@ chardet==4.0.0
     #   tabulator
 charset-normalizer==2.0.7
     # via
+    #   -r requirements/requirements-docs.txt
     #   -r requirements/requirements.txt
     #   requests
 ckanapi==4.6
@@ -93,12 +102,10 @@ cligj==0.7.2
     #   -r requirements/requirements.txt
     #   fiona
     #   rasterio
-colorlog==6.6.0
-    # via
-    #   -r requirements/requirements.txt
-    #   hdx-python-utilities
 coverage[toml]==6.1.2
-    # via pytest-cov
+    # via
+    #   -r requirements/requirements-tests.txt
+    #   pytest-cov
 cryptography==35.0.0
     # via
     #   -r requirements/requirements.txt
@@ -108,7 +115,9 @@ decorator==5.1.0
     #   -r requirements/requirements.txt
     #   jsonpath-ng
 distlib==0.3.3
-    # via virtualenv
+    # via
+    #   -r requirements/requirements-tests.txt
+    #   virtualenv
 dnspython==2.1.0
     # via
     #   -r requirements/requirements.txt
@@ -120,6 +129,7 @@ docopt==0.6.2
     #   num2words
 docutils==0.17.1
     # via
+    #   -r requirements/requirements-docs.txt
     #   sphinx
     #   sphinx-rtd-theme
 email-validator==1.1.3
@@ -136,6 +146,7 @@ exchangerates==0.3.4
     #   hdx-python-country
 filelock==3.4.0
     # via
+    #   -r requirements/requirements-tests.txt
     #   tox
     #   virtualenv
 fiona==1.8.20
@@ -148,13 +159,13 @@ greenlet==1.1.2
     # via
     #   -r requirements/requirements.txt
     #   sqlalchemy
-hdx-python-api==5.4.9
+hdx-python-api==5.5.8
     # via -r requirements/requirements.txt
-hdx-python-country==3.0.6
+hdx-python-country==3.1.3
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-api
-hdx-python-utilities==3.0.7
+hdx-python-utilities==3.1.7
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-country
@@ -166,6 +177,7 @@ identify==2.3.7
     # via pre-commit
 idna==3.3
     # via
+    #   -r requirements/requirements-docs.txt
     #   -r requirements/requirements.txt
     #   email-validator
     #   requests
@@ -174,15 +186,21 @@ ijson==3.1.4
     #   -r requirements/requirements.txt
     #   tabulator
 imagesize==1.3.0
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 inflect==5.3.0
     # via
     #   -r requirements/requirements.txt
     #   quantulum3
 iniconfig==1.1.1
-    # via pytest
+    # via
+    #   -r requirements/requirements-tests.txt
+    #   pytest
 jinja2==3.0.3
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 jmespath==0.10.0
     # via
     #   -r requirements/requirements.txt
@@ -204,12 +222,18 @@ linear-tsv==1.1.0
     # via
     #   -r requirements/requirements.txt
     #   tabulator
+loguru==0.6.0
+    # via
+    #   -r requirements/requirements.txt
+    #   hdx-python-utilities
 lxml==4.6.4
     # via
     #   -r requirements/requirements.txt
     #   exchangerates
 markupsafe==2.0.1
-    # via jinja2
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   jinja2
 munch==2.5.0
     # via
     #   -r requirements/requirements.txt
@@ -219,7 +243,7 @@ ndg-httpsclient==0.5.1
     #   -r requirements/requirements.txt
     #   hdx-python-api
 netcdf4==1.5.8
-    # via -r requirements/tests.in
+    # via -r requirements/requirements-tests.txt
 nodeenv==1.6.0
     # via pre-commit
 num2words==0.5.10
@@ -228,6 +252,7 @@ num2words==0.5.10
     #   quantulum3
 numpy==1.19.5
     # via
+    #   -r requirements/requirements-tests.txt
     #   -r requirements/requirements.txt
     #   cftime
     #   netcdf4
@@ -241,6 +266,8 @@ openpyxl==3.0.9
     #   tabulator
 packaging==21.3
     # via
+    #   -r requirements/requirements-docs.txt
+    #   -r requirements/requirements-tests.txt
     #   -r requirements/requirements.txt
     #   pytest
     #   rioxarray
@@ -252,15 +279,20 @@ pandas==1.3.4
     #   geopandas
     #   xarray
 pbr==5.8.0
-    # via sphinxcontrib-apidoc
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinxcontrib-apidoc
 pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements/dev.in
 platformdirs==2.4.0
-    # via virtualenv
+    # via
+    #   -r requirements/requirements-tests.txt
+    #   virtualenv
 pluggy==1.0.0
     # via
+    #   -r requirements/requirements-tests.txt
     #   pytest
     #   tox
 ply==3.11
@@ -272,6 +304,7 @@ pre-commit==2.15.0
     # via -r requirements/dev.in
 py==1.11.0
     # via
+    #   -r requirements/requirements-tests.txt
     #   pytest
     #   tox
 pyasn1==0.4.8
@@ -286,7 +319,9 @@ pycparser==2.21
 pydantic==1.8.2
     # via -r requirements/requirements.txt
 pygments==2.10.0
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 pyopenssl==21.0.0
     # via
     #   -r requirements/requirements.txt
@@ -294,6 +329,8 @@ pyopenssl==21.0.0
     #   ndg-httpsclient
 pyparsing==3.0.6
     # via
+    #   -r requirements/requirements-docs.txt
+    #   -r requirements/requirements-tests.txt
     #   -r requirements/requirements.txt
     #   packaging
     #   snuggs
@@ -308,13 +345,13 @@ pyproj==3.3.0
     #   rioxarray
 pytest==6.2.5
     # via
-    #   -r requirements/tests.in
+    #   -r requirements/requirements-tests.txt
     #   pytest-cov
     #   pytest-mock
 pytest-cov==3.0.0
-    # via -r requirements/tests.in
+    # via -r requirements/requirements-tests.txt
 pytest-mock==3.6.1
-    # via -r requirements/tests.in
+    # via -r requirements/requirements-tests.txt
 python-dateutil==2.8.2
     # via
     #   -r requirements/requirements.txt
@@ -332,6 +369,7 @@ python-slugify==5.0.2
     #   ckanapi
 pytz==2021.3
     # via
+    #   -r requirements/requirements-docs.txt
     #   -r requirements/requirements.txt
     #   babel
     #   pandas
@@ -353,6 +391,7 @@ ratelimit==2.2.1
     #   hdx-python-utilities
 requests==2.26.0
     # via
+    #   -r requirements/requirements-docs.txt
     #   -r requirements/requirements.txt
     #   ckanapi
     #   exchangerates
@@ -389,6 +428,7 @@ shapely==1.8.0
     #   geopandas
 six==1.16.0
     # via
+    #   -r requirements/requirements-tests.txt
     #   -r requirements/requirements.txt
     #   basicauth
     #   ckanapi
@@ -406,7 +446,9 @@ six==1.16.0
     #   url-normalize
     #   virtualenv
 snowballstemmer==2.2.0
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 snuggs==1.4.7
     # via
     #   -r requirements/requirements.txt
@@ -417,25 +459,37 @@ soupsieve==2.3.1
     #   beautifulsoup4
 sphinx==4.3.0
     # via
-    #   -r requirements/docs.in
+    #   -r requirements/requirements-docs.txt
     #   sphinx-rtd-theme
     #   sphinxcontrib-apidoc
 sphinx-rtd-theme==1.0.0
-    # via -r requirements/docs.in
+    # via -r requirements/requirements-docs.txt
 sphinxcontrib-apidoc==0.3.0
-    # via -r requirements/docs.in
+    # via -r requirements/requirements-docs.txt
 sphinxcontrib-applehelp==1.0.2
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 sphinxcontrib-devhelp==1.0.2
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 sphinxcontrib-htmlhelp==2.0.0
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 sphinxcontrib-jsmath==1.0.1
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 sphinxcontrib-qthelp==1.0.3
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 sphinxcontrib-serializinghtml==1.1.5
-    # via sphinx
+    # via
+    #   -r requirements/requirements-docs.txt
+    #   sphinx
 sqlalchemy==1.4.27
     # via
     #   -r requirements/requirements.txt
@@ -450,15 +504,17 @@ text-unidecode==1.3
     #   python-slugify
 toml==0.10.2
     # via
+    #   -r requirements/requirements-tests.txt
     #   pre-commit
     #   pytest
     #   tox
 tomli==1.2.2
     # via
+    #   -r requirements/requirements-tests.txt
     #   coverage
     #   pep517
 tox==3.24.5
-    # via -r requirements/tests.in
+    # via -r requirements/requirements-tests.txt
 typing-extensions==4.0.0
     # via
     #   -r requirements/requirements.txt
@@ -478,12 +534,14 @@ url-normalize==1.4.3
     #   requests-cache
 urllib3==1.26.7
     # via
+    #   -r requirements/requirements-docs.txt
     #   -r requirements/requirements.txt
     #   botocore
     #   requests
     #   requests-cache
 virtualenv==20.10.0
     # via
+    #   -r requirements/requirements-tests.txt
     #   pre-commit
     #   tox
 webencodings==0.5.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -51,8 +51,6 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-colorlog==6.6.0
-    # via hdx-python-utilities
 cryptography==35.0.0
     # via pyopenssl
 decorator==5.1.0
@@ -75,11 +73,11 @@ geopandas==0.10.2
     # via aa-toolbox (setup.cfg)
 greenlet==1.1.2
     # via sqlalchemy
-hdx-python-api==5.4.9
+hdx-python-api==5.5.8
     # via aa-toolbox (setup.cfg)
-hdx-python-country==3.0.6
+hdx-python-country==3.1.3
     # via hdx-python-api
-hdx-python-utilities==3.0.7
+hdx-python-utilities==3.1.7
     # via hdx-python-country
 html5lib==1.1
     # via hdx-python-utilities
@@ -103,6 +101,8 @@ libhxl==4.24.1
     # via hdx-python-country
 linear-tsv==1.1.0
     # via tabulator
+loguru==0.6.0
+    # via hdx-python-utilities
 lxml==4.6.4
     # via exchangerates
 munch==2.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = true
 python_requires = >= 3.6, < 3.10
 install_requires =
     geopandas
-    hdx-python-api>=5.4.9
+    hdx-python-api>=5.5.8
     numpy
     pydantic
     requests


### PR DESCRIPTION
Set min HDX API version to fix download bug. 

Also snuck in a small change to generate dev requirements from the pinned txt files rather than the .in files, which could results in incompatible versions. 