### PR TITLE
Add wrapt decorator to check file existence for instance methods

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -553,6 +553,8 @@ wheel==0.37.0
     #   -r requirements/requirements.txt
     #   libhxl
     #   pip-tools
+wrapt==1.14.0
+    # via -r requirements/requirements.txt
 xarray==0.20.1
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -241,6 +241,8 @@ webencodings==0.5.1
     # via html5lib
 wheel==0.37.0
     # via libhxl
+wrapt==1.14.0
+    # via aa-toolbox (setup.cfg)
 xarray==0.20.1
     # via
     #   aa-toolbox (setup.cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,11 @@ install_requires =
     hdx-python-api>=5.5.8
     numpy
     pydantic
-    requests
     pyyaml
+    requests
     rioxarray
     typing-extensions
+    wrapt
     xarray
 
 [options.packages.find]


### PR DESCRIPTION
Attempt to address #62. Uses [wrapt](https://wrapt.readthedocs.io/en/latest/quick-start.html) which allows one standard decorator for instance methods, class methods, functions, etc. by ensuring bound object not passed to args.

However, I couldn't eventually wrap my head around how to implement your typing cast in the same way as in the original. As well, would need to implement some tests on the decorator during changing. Putting here because is WIP, but taking me a while to wrap my head around as I'm quite rusty now.