### PR TITLE
Datasource abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 - Implemented downloading and processing for IRI seasonal precipitation forecast
 - Added config for DRC (of which the iso3 is COD)
 
+### Changed
+
+- `DataSource` is now an abstract base class with required `download`, `process`
+  and `load` methods
+
 ### Removed
 
 - `Pipeline` class no longer used as main API

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -28,8 +28,6 @@ from aatoolbox.utils.io import check_file_existence
 
 logger = logging.getLogger(__name__)
 
-_MODULE_BASENAME = "cod_ab"
-
 
 class CodAB(DataSource):
     """
@@ -43,11 +41,11 @@ class CodAB(DataSource):
 
     def __init__(self, country_config: CountryConfig):
         super().__init__(
-            country_config, module_base_dir=_MODULE_BASENAME, is_public=True
+            country_config, module_base_dir="cod_ab", is_public=True
         )
         self._raw_filepath = (
             self._raw_base_dir
-            / f"{self._country_config.iso3}_{_MODULE_BASENAME}.shp.zip"
+            / f"{self._country_config.iso3}_{self._module_base_dir}.shp.zip"
         )
 
     def download(self, clobber: bool = False) -> Path:
@@ -86,9 +84,6 @@ class CodAB(DataSource):
         """
         logger.info("`process()` method not implemented for CodAB.")
 
-    # next line ignored to avoid PEP8 error
-    # described here:
-    # https://stackoverflow.com/questions/42778784/abstract-classes-with-varying-amounts-of-parameters
     def load(self, admin_level: int) -> gpd.GeoDataFrame:  # type: ignore
         """
         Get the COD AB data by admin level.

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -21,14 +21,14 @@ import geopandas as gpd
 from fiona.errors import DriverError
 
 from aatoolbox.config.countryconfig import CountryConfig
-from aatoolbox.datasources.datasource import DataSource
+from aatoolbox.datasources.datasource import DataSourceNoProcess
 from aatoolbox.utils.hdx_api import load_dataset_from_hdx
 from aatoolbox.utils.io import check_file_existence
 
 _MODULE_BASENAME = "cod_ab"
 
 
-class CodAB(DataSource):
+class CodAB(DataSourceNoProcess):
     """
     Work with COD AB (administrative boundaries).
 
@@ -75,7 +75,7 @@ class CodAB(DataSource):
             clobber=clobber,
         )
 
-    def load(self, admin_level: int) -> gpd.GeoDataFrame:
+    def load(self, admin_level: int) -> gpd.GeoDataFrame:  # type: ignore
         """
         Get the COD AB data by admin level.
 

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -75,6 +75,9 @@ class CodAB(DataSourceNoProcess):
             clobber=clobber,
         )
 
+    # next line ignored to avoid PEP8 error
+    # described here:
+    # https://stackoverflow.com/questions/42778784/abstract-classes-with-varying-amounts-of-parameters
     def load(self, admin_level: int) -> gpd.GeoDataFrame:  # type: ignore
         """
         Get the COD AB data by admin level.

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -78,7 +78,7 @@ class CodAB(DataSource):
             clobber=clobber,
         )
 
-    def process(self, a, *args, **kwargs):
+    def process(self, *args, **kwargs):
         """
         Process COD AB data.
 

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -78,13 +78,13 @@ class CodAB(DataSource):
             clobber=clobber,
         )
 
-    def process(self):
+    def process(self, *args, **kwargs):
         """
         Process COD AB data.
 
         Method not implemented.
         """
-        logger.message("`process()` method not implemented for CodAB.")
+        logger.info("`process()` method not implemented for CodAB.")
 
     # next line ignored to avoid PEP8 error
     # described here:

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -15,20 +15,23 @@ Finally, use the load method to begin working with the data as a
 GeoPandas dataframe:
 >>> npl_admin1 = codab.load(admin_level=1)
 """
+import logging
 from pathlib import Path
 
 import geopandas as gpd
 from fiona.errors import DriverError
 
 from aatoolbox.config.countryconfig import CountryConfig
-from aatoolbox.datasources.datasource import DataSourceNoProcess
+from aatoolbox.datasources.datasource import DataSource
 from aatoolbox.utils.hdx_api import load_dataset_from_hdx
 from aatoolbox.utils.io import check_file_existence
+
+logger = logging.getLogger(__name__)
 
 _MODULE_BASENAME = "cod_ab"
 
 
-class CodAB(DataSourceNoProcess):
+class CodAB(DataSource):
     """
     Work with COD AB (administrative boundaries).
 
@@ -74,6 +77,14 @@ class CodAB(DataSourceNoProcess):
             hdx_dataset_name=self._country_config.codab.hdx_dataset_name,
             clobber=clobber,
         )
+
+    def process(self):
+        """
+        Process COD AB data.
+
+        Method not implemented.
+        """
+        logger.message("`process()` method not implemented for CodAB.")
 
     # next line ignored to avoid PEP8 error
     # described here:

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -78,7 +78,7 @@ class CodAB(DataSource):
             clobber=clobber,
         )
 
-    def process(self, *args, **kwargs):
+    def process(self, a, *args, **kwargs):
         """
         Process COD AB data.
 

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -61,12 +61,12 @@ class DataSource(ABC):
         )
 
     @abstractmethod
-    def download(self):
+    def download(self, clobber):
         """Abstract method for downloading."""
         pass
 
     @abstractmethod
-    def process(self):
+    def process(self, *args, **kwargs):
         """Abstract method for processing."""
         pass
 

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -1,13 +1,14 @@
 """Base class for aatoolbox data source."""
+from abc import ABC, abstractmethod
 from pathlib import Path
 
 from aatoolbox.config.countryconfig import CountryConfig
 from aatoolbox.config.pathconfig import PathConfig
 
 
-class DataSource:
+class DataSourceBase(ABC):
     """
-    Base class object that contains path convenience functions.
+    Base abstract class object that contains path convenience functions.
 
     Parameters
     ----------
@@ -20,6 +21,7 @@ class DataSource:
         directory structure.
     """
 
+    @abstractmethod
     def __init__(
         self,
         country_config: CountryConfig,
@@ -53,3 +55,57 @@ class DataSource:
             / self._country_config.iso3
             / self._module_base_dir
         )
+
+
+class DataSourceNoProcess(DataSourceBase):
+    """
+    Base abstract class object that contains path convenience functions.
+
+    Cannot itself be instantiated. Does not include abstract method for
+    ``process()``, since some subclasses like CodAB do not require them.
+
+    Parameters
+    ----------
+    country_config: CountryConfig
+        Country configuration
+    module_base_dir : str
+        Module directory name (usually correspond to data source)
+    is_public: bool, default = False
+        Whether the dataset is public or private. Determines top-level
+        directory structure.
+    """
+
+    @abstractmethod
+    def download(self):
+        """Abstract method for downloading."""
+        pass
+
+    @abstractmethod
+    def load(self):
+        """Abstract method for loading."""
+        pass
+
+
+class DataSource(DataSourceNoProcess):
+    """
+    Base abstract class object that contains path convenience functions.
+
+    Cannot itself be instantiated. ``__init__``, ``download()``,
+    ``load()``, and ``process()`` methods required for subclass to be
+    instantiated.
+
+    Parameters
+    ----------
+    country_config: CountryConfig
+        Country configuration
+    module_base_dir : str
+        Module directory name (usually correspond to data source)
+    is_public: bool, default = False
+        Whether the dataset is public or private. Determines top-level
+        directory structure.
+    """
+
+    @abstractmethod
+    def process(self):
+        """Abstract method for processing."""
+        pass

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -60,12 +60,12 @@ class DataSource(ABC):
         )
 
     @abstractmethod
-    def download(self, clobber):
+    def download(self, clobber: bool = False):
         """Abstract method for downloading."""
         pass
 
     @abstractmethod
-    def process(self, clobber):
+    def process(self, clobber: bool = False):
         """Abstract method for processing."""
         pass
 

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -32,7 +32,6 @@ class DataSource(ABC):
         module_base_dir: str,
         is_public: bool = False,
     ):
-
         self._country_config = country_config
         self._module_base_dir = module_base_dir
         self._path_config = PathConfig()

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -66,7 +66,7 @@ class DataSource(ABC):
         pass
 
     @abstractmethod
-    def process(self, *args, **kwargs):
+    def process(self, clobber):
         """Abstract method for processing."""
         pass
 

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -6,9 +6,13 @@ from aatoolbox.config.countryconfig import CountryConfig
 from aatoolbox.config.pathconfig import PathConfig
 
 
-class DataSourceBase(ABC):
+class DataSource(ABC):
     """
     Base abstract class object that contains path convenience functions.
+
+    Cannot itself be instantiated. ``__init__``, ``download()``,
+    ``load()``, and ``process()`` methods required for subclass to be
+    instantiated.
 
     Parameters
     ----------
@@ -56,56 +60,17 @@ class DataSourceBase(ABC):
             / self._module_base_dir
         )
 
-
-class DataSourceNoProcess(DataSourceBase):
-    """
-    Base abstract class object that contains path convenience functions.
-
-    Cannot itself be instantiated. Does not include abstract method for
-    ``process()``, since some subclasses like CodAB do not require them.
-
-    Parameters
-    ----------
-    country_config: CountryConfig
-        Country configuration
-    module_base_dir : str
-        Module directory name (usually correspond to data source)
-    is_public: bool, default = False
-        Whether the dataset is public or private. Determines top-level
-        directory structure.
-    """
-
     @abstractmethod
     def download(self):
         """Abstract method for downloading."""
         pass
 
     @abstractmethod
-    def load(self):
-        """Abstract method for loading."""
-        pass
-
-
-class DataSource(DataSourceNoProcess):
-    """
-    Base abstract class object that contains path convenience functions.
-
-    Cannot itself be instantiated. ``__init__``, ``download()``,
-    ``load()``, and ``process()`` methods required for subclass to be
-    instantiated.
-
-    Parameters
-    ----------
-    country_config: CountryConfig
-        Country configuration
-    module_base_dir : str
-        Module directory name (usually correspond to data source)
-    is_public: bool, default = False
-        Whether the dataset is public or private. Determines top-level
-        directory structure.
-    """
-
-    @abstractmethod
     def process(self):
         """Abstract method for processing."""
+        pass
+
+    @abstractmethod
+    def load(self):
+        """Abstract method for loading."""
         pass

--- a/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
+++ b/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
@@ -108,7 +108,7 @@ class _IriForecast(DataSource):
             clobber=clobber,
         )
 
-    def process(self, clobber: bool = False) -> Path:
+    def process(self, clobber: bool = False, *args, **kwargs) -> Path:
         """
         Process the IRI forecast.
 

--- a/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
+++ b/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
@@ -108,7 +108,7 @@ class _IriForecast(DataSource):
             clobber=clobber,
         )
 
-    def process(self, clobber: bool = False, *args, **kwargs) -> Path:
+    def process(self, clobber: bool = False) -> Path:
         """
         Process the IRI forecast.
 

--- a/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
+++ b/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
@@ -24,7 +24,6 @@ from aatoolbox.utils.io import check_file_existence
 
 logger = logging.getLogger(__name__)
 
-_MODULE_BASENAME = "iri"
 _IRI_AUTH = "IRI_AUTH"
 
 
@@ -54,7 +53,7 @@ class _IriForecast(DataSource):
     ):
         super().__init__(
             country_config=country_config,
-            module_base_dir=_MODULE_BASENAME,
+            module_base_dir="iri",
             is_public=False,
         )
         # round coordinates to correspond with the grid IRI publishes


### PR DESCRIPTION
Addresses #61. Creates the DataSource as an abstract base class with abstract methods. Some issues that arise are:

- All abstract methods must be overridden for a derived class to be instantiated. Thus, `CodAB` requires a different abstract base class since it lacks a `process()` method.
- There are varying parameters that will be passed to the methods `download()`, `process()`, and `load()` in derived classes (like in `CodAB`, where `load()` takes the admin level as an argument). This is an issue with [PEP8](https://stackoverflow.com/questions/42778784/abstract-classes-with-varying-amounts-of-parameters) caught by mypy and has to be excepted. The only alternative would be not to have abstract methods for the above, and just have an abstract method for `__init__`, which would be cleaner for having a single `DataSource` abstract class, but lose the ability to force derived classes to have the other 3 methods explicitly.