### PR TITLE
Use unique temporary directories for tests

### DIFF
--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -41,11 +41,11 @@ class CodAB(DataSource):
 
     def __init__(self, country_config: CountryConfig):
         super().__init__(
-            country_config, module_base_dir="cod_ab", is_public=True
+            country_config, datasource_base_dir="cod_ab", is_public=True
         )
         self._raw_filepath = (
-            self._raw_base_dir
-            / f"{self._country_config.iso3}_{self._module_base_dir}.shp.zip"
+            self._raw_base_dir / f"{self._country_config.iso3}_"
+            f"{self._datasource_base_dir}.shp.zip"
         )
 
     def download(self, clobber: bool = False) -> Path:

--- a/src/aatoolbox/datasources/datasource.py
+++ b/src/aatoolbox/datasources/datasource.py
@@ -20,7 +20,7 @@ class DataSource(ABC):
     ----------
     country_config: CountryConfig
         Country configuration
-    module_base_dir : str
+    datasource_base_dir : str
         Module directory name (usually correspond to data source)
     is_public: bool, default = False
         Whether the dataset is public or private. Determines top-level
@@ -31,11 +31,11 @@ class DataSource(ABC):
     def __init__(
         self,
         country_config: CountryConfig,
-        module_base_dir: str,
+        datasource_base_dir: str,
         is_public: bool = False,
     ):
         self._country_config = country_config
-        self._module_base_dir = module_base_dir
+        self._datasource_base_dir = datasource_base_dir
         self._path_config = PathConfig()
         self._raw_base_dir = self._get_base_dir(
             is_public=is_public,
@@ -81,7 +81,7 @@ class DataSource(ABC):
             / permission_dir
             / state_dir
             / region_dir
-            / self._module_base_dir
+            / self._datasource_base_dir
         )
 
     @abstractmethod

--- a/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
+++ b/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
@@ -53,7 +53,7 @@ class _IriForecast(DataSource):
     ):
         super().__init__(
             country_config=country_config,
-            module_base_dir="iri",
+            datasource_base_dir="iri",
             is_public=False,
         )
         # round coordinates to correspond with the grid IRI publishes

--- a/tests/datasources/conftest.py
+++ b/tests/datasources/conftest.py
@@ -5,17 +5,20 @@ from aatoolbox import create_country_config
 from aatoolbox.utils.io import parse_yaml
 
 CONFIG_FILE = "tests/datasources/fake_config.yaml"
-FAKE_AA_DATA_DIR = "fake_aa_dir"
 ISO3 = "abc"
 
 
 @pytest.fixture(autouse=True)
-def mock_aa_data_dir(mocker):
+def mock_aa_data_dir(tmp_path_factory, mocker):
     """Mock out the AA_DATA_DIR environment variable."""
+    mock_aa_data_dir_path = tmp_path_factory.mktemp(
+        basename="test_aa_data_dir"
+    )
     mocker.patch.dict(
         "aatoolbox.config.pathconfig.os.environ",
-        {"AA_DATA_DIR": FAKE_AA_DATA_DIR},
+        {"AA_DATA_DIR": str(mock_aa_data_dir_path)},
     )
+    return mock_aa_data_dir_path
 
 
 @pytest.fixture

--- a/tests/datasources/test_codab.py
+++ b/tests/datasources/test_codab.py
@@ -5,7 +5,7 @@ import pytest
 
 from aatoolbox import CodAB
 
-MODULE_BASENAME = "cod_ab"
+DATASOURCE_BASE_DIR = "cod_ab"
 
 
 @pytest.fixture
@@ -31,8 +31,8 @@ def test_codab_download(mock_aa_data_dir, mock_country_config, downloader):
         hdx_dataset_name=mock_country_config.codab.hdx_dataset_name,
         output_filepath=mock_aa_data_dir
         / f"public/raw/{mock_country_config.iso3}/"
-        f"{MODULE_BASENAME}/{mock_country_config.iso3}_"
-        f"{MODULE_BASENAME}.shp.zip",
+        f"{DATASOURCE_BASE_DIR}/{mock_country_config.iso3}_"
+        f"{DATASOURCE_BASE_DIR}.shp.zip",
     )
 
 
@@ -49,8 +49,8 @@ def test_codab_load_admin_level(
 
     gpd_read_file.assert_called_with(
         f"zip:///{mock_aa_data_dir}/public/raw/{mock_country_config.iso3}/"
-        f"{MODULE_BASENAME}/{mock_country_config.iso3}_{MODULE_BASENAME}"
-        f".shp.zip/{expected_layer_name}"
+        f"{DATASOURCE_BASE_DIR}/{mock_country_config.iso3}_"
+        f"{DATASOURCE_BASE_DIR}.shp.zip/{expected_layer_name}"
     )
 
 
@@ -70,8 +70,9 @@ def test_codab_custom(mock_aa_data_dir, mock_country_config, gpd_read_file):
     codab.load_custom(custom_layer_number)
     gpd_read_file.assert_called_with(
         f"zip:///{mock_aa_data_dir}/public/raw/{mock_country_config.iso3}/"
-        f"{MODULE_BASENAME}/{mock_country_config.iso3}_{MODULE_BASENAME}"
-        f".shp.zip/{custom_layer_name_list[custom_layer_number]}"
+        f"{DATASOURCE_BASE_DIR}/{mock_country_config.iso3}_"
+        f"{DATASOURCE_BASE_DIR}.shp.zip/"
+        f"{custom_layer_name_list[custom_layer_number]}"
     )
 
 

--- a/tests/datasources/test_codab.py
+++ b/tests/datasources/test_codab.py
@@ -3,9 +3,6 @@ from pathlib import Path
 
 import pytest
 
-# TODO: this will break if there is another conftest
-from conftest import FAKE_AA_DATA_DIR, ISO3
-
 from aatoolbox import CodAB
 
 MODULE_BASENAME = "cod_ab"
@@ -25,20 +22,23 @@ def gpd_read_file(mocker):
     return mocker.patch("aatoolbox.datasources.codab.codab.gpd.read_file")
 
 
-def test_codab_download(mock_country_config, downloader):
+def test_codab_download(mock_aa_data_dir, mock_country_config, downloader):
     """Test that load_codab calls the HDX API to download."""
     codab = CodAB(country_config=mock_country_config)
     codab.download()
     downloader.assert_called_with(
-        hdx_address=f"cod-ab-{ISO3}",
+        hdx_address=f"cod-ab-{mock_country_config.iso3}",
         hdx_dataset_name=mock_country_config.codab.hdx_dataset_name,
-        output_filepath=Path(FAKE_AA_DATA_DIR)
-        / f"public/raw/{ISO3}/{MODULE_BASENAME}/"
-        f"{ISO3}_{MODULE_BASENAME}.shp.zip",
+        output_filepath=mock_aa_data_dir
+        / f"public/raw/{mock_country_config.iso3}/"
+        f"{MODULE_BASENAME}/{mock_country_config.iso3}_"
+        f"{MODULE_BASENAME}.shp.zip",
     )
 
 
-def test_codab_load_admin_level(mock_country_config, gpd_read_file):
+def test_codab_load_admin_level(
+    mock_aa_data_dir, mock_country_config, gpd_read_file
+):
     """Test that load_codab retrieves expected file and layer name."""
     codab = CodAB(country_config=mock_country_config)
     admin_level = 2
@@ -48,8 +48,9 @@ def test_codab_load_admin_level(mock_country_config, gpd_read_file):
     codab.load(admin_level=admin_level)
 
     gpd_read_file.assert_called_with(
-        f"zip:///{FAKE_AA_DATA_DIR}/public/raw/{ISO3}/{MODULE_BASENAME}/"
-        f"{ISO3}_{MODULE_BASENAME}.shp.zip/{expected_layer_name}"
+        f"zip:///{mock_aa_data_dir}/public/raw/{mock_country_config.iso3}/"
+        f"{MODULE_BASENAME}/{mock_country_config.iso3}_{MODULE_BASENAME}"
+        f".shp.zip/{expected_layer_name}"
     )
 
 
@@ -60,7 +61,7 @@ def test_codab_too_high_admin_level(mock_country_config):
         codab.load(admin_level=10)
 
 
-def test_codab_custom(mock_country_config, gpd_read_file):
+def test_codab_custom(mock_aa_data_dir, mock_country_config, gpd_read_file):
     """Test that load_codab_custom retrieves expected file and layer name."""
     custom_layer_number = 1
     custom_layer_name_list = ["custom_layer_A", "custom_layer_B"]
@@ -68,9 +69,9 @@ def test_codab_custom(mock_country_config, gpd_read_file):
     codab = CodAB(country_config=mock_country_config)
     codab.load_custom(custom_layer_number)
     gpd_read_file.assert_called_with(
-        f"zip:///{FAKE_AA_DATA_DIR}/public/raw/{ISO3}/{MODULE_BASENAME}/"
-        f"{ISO3}_{MODULE_BASENAME}.shp.zip/"
-        f"{custom_layer_name_list[custom_layer_number]}"
+        f"zip:///{mock_aa_data_dir}/public/raw/{mock_country_config.iso3}/"
+        f"{MODULE_BASENAME}/{mock_country_config.iso3}_{MODULE_BASENAME}"
+        f".shp.zip/{custom_layer_name_list[custom_layer_number]}"
     )
 
 

--- a/tests/datasources/test_iri.py
+++ b/tests/datasources/test_iri.py
@@ -6,9 +6,6 @@ import cftime
 import numpy as np
 import pytest
 import xarray as xr
-
-# TODO: this will break if there is another conftest
-from conftest import FAKE_AA_DATA_DIR, ISO3
 from xarray.coding.cftimeindex import CFTimeIndex
 
 from aatoolbox import GeoBoundingBox, IriForecastDominant, IriForecastProb
@@ -66,7 +63,9 @@ def mock_download(mocker, mock_iri):
     return _mock_download
 
 
-def test_download_call_prob(mock_download):
+def test_download_call_prob(
+    mock_download, mock_aa_data_dir, mock_country_config
+):
     """Test download for tercile probability forecast."""
     url, filepath = mock_download(prob_forecast=True)
     assert url == (
@@ -77,13 +76,16 @@ def test_download_call_prob(mock_download):
     )
 
     assert filepath == (
-        Path(FAKE_AA_DATA_DIR) / f"private/raw/{ISO3}/{MODULE_BASENAME}/"
+        mock_aa_data_dir
+        / f"private/raw/{mock_country_config.iso3}/{MODULE_BASENAME}/"
         f"abc_iri_forecast_seasonal_precipitation_"
         f"tercile_prob_Np6Sp3Em2Wp3.nc"
     )
 
 
-def test_download_call_dominant(mock_download):
+def test_download_call_dominant(
+    mock_download, mock_aa_data_dir, mock_country_config
+):
     """Test download for dominant tercile forecast."""
     url, filepath = mock_download(prob_forecast=False)
     assert url == (
@@ -94,15 +96,14 @@ def test_download_call_dominant(mock_download):
     )
 
     assert filepath == (
-        Path(FAKE_AA_DATA_DIR) / f"private/raw/{ISO3}/{MODULE_BASENAME}/"
+        mock_aa_data_dir
+        / f"private/raw/{mock_country_config.iso3}/{MODULE_BASENAME}/"
         f"abc_iri_forecast_seasonal_"
         f"precipitation_tercile_dominant_Np6Sp3Em2Wp3.nc"
     )
 
 
-# TODO: need to use a tmp dir but will copy
-# that from glofas once that is ready :)
-def test_process(mocker, mock_iri):
+def test_process(mocker, mock_iri, mock_aa_data_dir, mock_country_config):
     """Test process for IRI forecast."""
     ds = xr.DataArray(
         np.reshape(a=np.arange(16), newshape=(2, 2, 2, 2)),
@@ -130,8 +131,9 @@ def test_process(mocker, mock_iri):
 
     processed_path = iri.process()
     assert processed_path == (
-        Path(FAKE_AA_DATA_DIR) / f"private/processed/{ISO3}/{MODULE_BASENAME}/"
-        f"{ISO3}_iri_forecast_seasonal_precipitation_"
+        mock_aa_data_dir
+        / f"private/processed/{mock_country_config.iso3}/{MODULE_BASENAME}/"
+        f"{mock_country_config.iso3}_iri_forecast_seasonal_precipitation_"
         f"tercile_prob_Np6Sp3Em2Wp3.nc"
     )
 
@@ -175,7 +177,13 @@ def mock_xr_load_dataset(mocker):
     )
 
 
-def test_iri_load(mocker, mock_xr_load_dataset, mock_iri):
+def test_iri_load(
+    mocker,
+    mock_xr_load_dataset,
+    mock_iri,
+    mock_aa_data_dir,
+    mock_country_config,
+):
     """Test that load_codab calls the HDX API to download."""
     mocker.patch("aatoolbox.datasources.iri.iri_seasonal_forecast._download")
 
@@ -184,9 +192,10 @@ def test_iri_load(mocker, mock_xr_load_dataset, mock_iri):
     mock_xr_load_dataset.assert_has_calls(
         [
             mocker.call(
-                Path(FAKE_AA_DATA_DIR)
-                / f"private/processed/{ISO3}/{MODULE_BASENAME}/"
-                f"{ISO3}_iri_forecast_seasonal_precipitation_"
+                mock_aa_data_dir
+                / f"private/processed/{mock_country_config.iso3}/"
+                f"{MODULE_BASENAME}/{mock_country_config.iso3}"
+                f"_iri_forecast_seasonal_precipitation_"
                 f"tercile_prob_Np6Sp3Em2Wp3.nc"
             ),
         ]

--- a/tests/datasources/test_iri.py
+++ b/tests/datasources/test_iri.py
@@ -10,7 +10,7 @@ from xarray.coding.cftimeindex import CFTimeIndex
 
 from aatoolbox import GeoBoundingBox, IriForecastDominant, IriForecastProb
 
-MODULE_BASENAME = "iri"
+DATASOURCE_BASE_DIR = "iri"
 FAKE_IRI_AUTH = "FAKE_IRI_AUTH"
 
 
@@ -77,7 +77,7 @@ def test_download_call_prob(
 
     assert filepath == (
         mock_aa_data_dir
-        / f"private/raw/{mock_country_config.iso3}/{MODULE_BASENAME}/"
+        / f"private/raw/{mock_country_config.iso3}/{DATASOURCE_BASE_DIR}/"
         f"abc_iri_forecast_seasonal_precipitation_"
         f"tercile_prob_Np6Sp3Em2Wp3.nc"
     )
@@ -97,7 +97,7 @@ def test_download_call_dominant(
 
     assert filepath == (
         mock_aa_data_dir
-        / f"private/raw/{mock_country_config.iso3}/{MODULE_BASENAME}/"
+        / f"private/raw/{mock_country_config.iso3}/{DATASOURCE_BASE_DIR}/"
         f"abc_iri_forecast_seasonal_"
         f"precipitation_tercile_dominant_Np6Sp3Em2Wp3.nc"
     )
@@ -131,10 +131,9 @@ def test_process(mocker, mock_iri, mock_aa_data_dir, mock_country_config):
 
     processed_path = iri.process()
     assert processed_path == (
-        mock_aa_data_dir
-        / f"private/processed/{mock_country_config.iso3}/{MODULE_BASENAME}/"
-        f"{mock_country_config.iso3}_iri_forecast_seasonal_precipitation_"
-        f"tercile_prob_Np6Sp3Em2Wp3.nc"
+        mock_aa_data_dir / f"private/processed/{mock_country_config.iso3}/"
+        f"{DATASOURCE_BASE_DIR}/{mock_country_config.iso3}_"
+        f"iri_forecast_seasonal_precipitation_tercile_prob_Np6Sp3Em2Wp3.nc"
     )
 
     da_processed = xr.load_dataset(processed_path)
@@ -194,7 +193,7 @@ def test_iri_load(
             mocker.call(
                 mock_aa_data_dir
                 / f"private/processed/{mock_country_config.iso3}/"
-                f"{MODULE_BASENAME}/{mock_country_config.iso3}"
+                f"{DATASOURCE_BASE_DIR}/{mock_country_config.iso3}"
                 f"_iri_forecast_seasonal_precipitation_"
                 f"tercile_prob_Np6Sp3Em2Wp3.nc"
             ),


### PR DESCRIPTION
- Ensure that any data the tests create goes into a unique temporary directory
- I know I should have done this separately but I realized that `module_base_dir` is a dumb name and changed it to `datasource_base_dir`