### PR TITLE
add language_version to pre-commit pip-compile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,20 +46,28 @@ repos:
     hooks:
       - id: pip-compile
         name: pip-compile requirements.txt
+        language: python
+        language_version: python3.9
         files: setup.cfg
         args: [setup.cfg, -q, -o, requirements/requirements.txt]
       - id: pip-compile
         name: pip-compile requirements-docs.txt
+        language: python
+        language_version: python3.9
         files: requirements/docs.in
         args: [ requirements/docs.in, -q, -o,
                 requirements/requirements-docs.txt ]
       - id: pip-compile
         name: pip-compile requirements-tests.txt
+        language: python
+        language_version: python3.9
         files: requirements/tests.in
         args: [requirements/tests.in, -q, -o,
                requirements/requirements-tests.txt]
       - id: pip-compile
         name: pip-compile requirements-dev.txt
+        language: python
+        language_version: python3.9
         files: requirements/(dev.in|docs.in|tests.in|requirements.txt)
         args: [requirements/dev.in, -q, -o,
                requirements/requirements-dev.txt]


### PR DESCRIPTION
While trying to switch to python 3.9, I was having the same issue as Seth had. Namely that my version of pre-commit wasn't the same as my python version in my venv. 

Now it seems, you can force pre-commit to use a certain version, see [here](https://pre-commit.com/#overriding-language-version). This solved the issue for me and to me this seems like a logical thing to do. 

Let me know what you think! 