### PR TITLE
update hdx version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+    python: python3.9
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -46,28 +49,20 @@ repos:
     hooks:
       - id: pip-compile
         name: pip-compile requirements.txt
-        language: python
-        language_version: python3.9
         files: setup.cfg
         args: [setup.cfg, -q, -o, requirements/requirements.txt]
       - id: pip-compile
         name: pip-compile requirements-docs.txt
-        language: python
-        language_version: python3.9
         files: requirements/docs.in
         args: [ requirements/docs.in, -q, -o,
                 requirements/requirements-docs.txt ]
       - id: pip-compile
         name: pip-compile requirements-tests.txt
-        language: python
-        language_version: python3.9
         files: requirements/tests.in
         args: [requirements/tests.in, -q, -o,
                requirements/requirements-tests.txt]
       - id: pip-compile
         name: pip-compile requirements-dev.txt
-        language: python
-        language_version: python3.9
         files: requirements/(dev.in|docs.in|tests.in|requirements.txt)
         args: [requirements/dev.in, -q, -o,
                requirements/requirements-dev.txt]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,20 +46,28 @@ repos:
     hooks:
       - id: pip-compile
         name: pip-compile requirements.txt
+        language: python
+        language_version: python3.9
         files: setup.cfg
         args: [setup.cfg, -q, -o, requirements/requirements.txt]
       - id: pip-compile
         name: pip-compile requirements-docs.txt
+        language: python
+        language_version: python3.9
         files: requirements/docs.in
         args: [ requirements/docs.in, -q, -o,
                 requirements/requirements-docs.txt ]
       - id: pip-compile
         name: pip-compile requirements-tests.txt
+        language: python
+        language_version: python3.9
         files: requirements/tests.in
         args: [requirements/tests.in, -q, -o,
                requirements/requirements-tests.txt]
       - id: pip-compile
         name: pip-compile requirements-dev.txt
+        language: python
+        language_version: python3.9
         files: requirements/(dev.in|docs.in|tests.in|requirements.txt)
         args: [requirements/dev.in, -q, -o,
                requirements/requirements-dev.txt]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -180,13 +180,13 @@ fsspec==2022.3.0
     #   dask
 geopandas==0.10.2
     # via -r requirements/requirements.txt
-hdx-python-api==5.6.2
+hdx-python-api==5.6.4
     # via -r requirements/requirements.txt
-hdx-python-country==3.1.7
+hdx-python-country==3.1.9
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-api
-hdx-python-utilities==3.2.3
+hdx-python-utilities==3.2.8
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-country

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -94,13 +94,13 @@ fsspec==2022.3.0
     # via dask
 geopandas==0.10.2
     # via aa-toolbox (setup.cfg)
-hdx-python-api==5.6.2
+hdx-python-api==5.6.4
     # via aa-toolbox (setup.cfg)
-hdx-python-country==3.1.7
+hdx-python-country==3.1.9
     # via
     #   aa-toolbox (setup.cfg)
     #   hdx-python-api
-hdx-python-utilities==3.2.3
+hdx-python-utilities==3.2.8
     # via hdx-python-country
 heapdict==1.0.1
     # via zict

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >= 3.6
 # TODO: Remove the rasterio requirements once 1.3 is released
 install_requires =
     geopandas
-    hdx-python-api>=5.6.2
+    hdx-python-api>=5.6.4
     hdx-python-country
     numpy
     pydantic


### PR DESCRIPTION
While trying to download a hdx data source (in the `pa-global-monitoring`), I realized there is a bug in hdx-python-api 5.6.2, which has been fixed in 5.6.4. So we should force at least this version. 