### PR TITLE
Hotfix/hdx version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,16 @@ Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 adheres to `Semantic
 Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
+[0.4.2] - 2022-05-13
+--------------------
+
+Fixed
+~~~~~
+
+- Upgrade version of hdx-python-api to prevent bug when downloading
+
+
+
 [0.4.0] - 2022-04-21
 --------------------
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -164,7 +164,7 @@ fiona==1.8.21
     # via
     #   -r requirements/requirements.txt
     #   geopandas
-frictionless[excel,json]==4.29.0
+frictionless[excel,json]==4.34.0
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-utilities
@@ -174,13 +174,13 @@ fsspec==2022.3.0
     #   dask
 geopandas==0.10.2
     # via -r requirements/requirements.txt
-hdx-python-api==5.6.2
+hdx-python-api==5.6.5
     # via -r requirements/requirements.txt
-hdx-python-country==3.1.7
+hdx-python-country==3.2.1
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-api
-hdx-python-utilities==3.2.3
+hdx-python-utilities==3.3.1
     # via
     #   -r requirements/requirements.txt
     #   hdx-python-country
@@ -231,6 +231,7 @@ jinja2==3.1.1
     #   bokeh
     #   dask
     #   distributed
+    #   frictionless
     #   sphinx
 jsonlines==3.0.0
     # via
@@ -244,6 +245,7 @@ jsonschema==4.4.0
     # via
     #   -r requirements/requirements.txt
     #   frictionless
+    #   tableschema-to-template
 libhxl==4.25
     # via
     #   -r requirements/requirements.txt
@@ -456,6 +458,7 @@ pyyaml==6.0
     #   distributed
     #   frictionless
     #   pre-commit
+    #   tableschema-to-template
 quantulum3==0.7.10
     # via
     #   -r requirements/requirements.txt
@@ -585,6 +588,14 @@ stringcase==1.2.0
     # via
     #   -r requirements/requirements.txt
     #   frictionless
+tableschema-to-template==0.0.12
+    # via
+    #   -r requirements/requirements.txt
+    #   frictionless
+tabulate==0.8.9
+    # via
+    #   -r requirements/requirements.txt
+    #   frictionless
 tblib==1.7.0
     # via
     #   -r requirements/requirements.txt
@@ -675,6 +686,10 @@ xlrd3==1.1.0
     # via
     #   -r requirements/requirements.txt
     #   libhxl
+xlsxwriter==3.0.3
+    # via
+    #   -r requirements/requirements.txt
+    #   tableschema-to-template
 xlwt==1.3.0
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -82,19 +82,19 @@ exchangerates==0.3.4
     # via hdx-python-country
 fiona==1.8.21
     # via geopandas
-frictionless[excel,json]==4.29.0
+frictionless[excel,json]==4.34.0
     # via hdx-python-utilities
 fsspec==2022.3.0
     # via dask
 geopandas==0.10.2
     # via aa-toolbox (setup.cfg)
-hdx-python-api==5.6.2
+hdx-python-api==5.6.5
     # via aa-toolbox (setup.cfg)
-hdx-python-country==3.1.7
+hdx-python-country==3.2.1
     # via
     #   aa-toolbox (setup.cfg)
     #   hdx-python-api
-hdx-python-utilities==3.2.3
+hdx-python-utilities==3.3.1
     # via hdx-python-country
 heapdict==1.0.1
     # via zict
@@ -115,12 +115,15 @@ jinja2==3.1.1
     #   bokeh
     #   dask
     #   distributed
+    #   frictionless
 jsonlines==3.0.0
     # via frictionless
 jsonpath-ng==1.5.3
     # via libhxl
 jsonschema==4.4.0
-    # via frictionless
+    # via
+    #   frictionless
+    #   tableschema-to-template
 libhxl==4.25
     # via hdx-python-country
 locket==1.0.0
@@ -225,6 +228,7 @@ pyyaml==6.0
     #   dask
     #   distributed
     #   frictionless
+    #   tableschema-to-template
 quantulum3==0.7.10
     # via hdx-python-api
 rasterio==1.2.10
@@ -281,6 +285,10 @@ sphinxcontrib-napoleon==0.7
     # via defopt
 stringcase==1.2.0
     # via frictionless
+tableschema-to-template==0.0.12
+    # via frictionless
+tabulate==0.8.9
+    # via frictionless
 tblib==1.7.0
     # via distributed
 text-unidecode==1.3
@@ -329,6 +337,8 @@ xlrd==2.0.1
     # via frictionless
 xlrd3==1.1.0
     # via libhxl
+xlsxwriter==3.0.3
+    # via tableschema-to-template
 xlwt==1.3.0
     # via frictionless
 zict==2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >= 3.6
 # TODO: Remove the rasterio requirements once 1.3 is released
 install_requires =
     geopandas
-    hdx-python-api>=5.6.2
+    hdx-python-api>=5.6.4
     hdx-python-country
     numpy
     pydantic


### PR DESCRIPTION
While trying to download a hdx data source (in the pa-global-monitoring), I realized there is a bug in hdx-python-api 5.6.2, which has been fixed in 5.6.4. So we should force at least this version.