### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/run-python-tests.yaml
+++ b/.github/workflows/run-python-tests.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jazzband/pip-tools
-    rev: 6.6.0
+    rev: 6.9.0
     hooks:
       - id: pip-compile
         name: pip-compile requirements.txt

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -17,7 +17,7 @@ like the data to go.
 Install AA Toolbox
 ^^^^^^^^^^^^^^^^^^
 
-AA Toolbox supports Python 3.6 and newer. It can be installed in your Python
+AA Toolbox supports Python 3.7 and newer. It can be installed in your Python
 environment using the following command:
 
 .. code-block:: sh

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -233,7 +233,9 @@ pyyaml==6.0
 quantulum3==0.7.10
     # via hdx-python-api
 rasterio==1.2.10
-    # via rioxarray
+    # via
+    #   aa-toolbox (setup.cfg)
+    #   rioxarray
 ratelimit==2.2.1
     # via hdx-python-utilities
 requests==2.27.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.6
-# TODO: Remove the rasterio requirements once 1.3 is released
+python_requires = >= 3.7
 install_requires =
     cftime
     geopandas
@@ -38,7 +37,7 @@ install_requires =
     pydantic
     pyyaml
     requests
-    rasterio>=1.3a4;python_version=='3.10'
+    rasterio
     rioxarray
     typing-extensions
     wrapt

--- a/src/aatoolbox/utils/io.py
+++ b/src/aatoolbox/utils/io.py
@@ -29,7 +29,9 @@ def download_url(
     """
     save_path.parent.mkdir(exist_ok=True, parents=True)
     # Remove file if already exists
-    save_path.unlink(missing_ok=True)
+    # TODO: Use missing_ok=True once 3.7 is dropped
+    if save_path.exists():
+        save_path.unlink()
 
     # use a session and chunk_size to prevent
     # crashing when downloading large files while

--- a/tests/datasources/test_codab.py
+++ b/tests/datasources/test_codab.py
@@ -87,6 +87,7 @@ def test_codab_load_fail(mock_country_config):
     """Test raises file not found error when load fails."""
     codab = CodAB(country_config=mock_country_config)
     # Remove file if it exists
+    # TODO: Use missing_ok=True once 3.7 is dropped
     if codab._raw_filepath.exists():
         Path.unlink(codab._raw_filepath)
     with pytest.raises(FileNotFoundError) as excinfo:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 isolated_build = true
 envlist =
-    py36
     py37
     py38
     py39
@@ -21,7 +20,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
Resolves #132. 

I also:
- took out the `rasterio` req for 3.10 as it's not needed anymore
- (I think) fixed a bug in io.py where it would not have worked for 3.7 