### PR TITLE
Address #131

### DIFF
--- a/src/aatoolbox/utils/check_file_existence.py
+++ b/src/aatoolbox/utils/check_file_existence.py
@@ -58,11 +58,23 @@ def check_file_existence(
                 " decorator to work."
             )
         ) from err
-    if filepath.exists() and not clobber:
-        logger.info(
-            f"File {filepath} exists and clobber set to False, "
-            f"using existing files"
-        )
+
+    # check existence
+    exist_dict = {True: "exists", False: "does not exist"}
+
+    # check filepath exists -> clobber
+    usage_dict = {
+        True: {True: "overwriting existing", False: "using existing"},
+        False: {True: "downloading new", False: "downloading new"},
+    }
+    fp_exists = filepath.exists()
+
+    logger.info(
+        f"File {filepath} {exist_dict[fp_exists]} and clobber "
+        f"set to {clobber}, {usage_dict[fp_exists][clobber]} file."
+    )
+
+    if fp_exists and not clobber:
         return filepath
     else:
         return wrapped(*args, **kwargs)

--- a/tests/test_check_file_existence.py
+++ b/tests/test_check_file_existence.py
@@ -1,5 +1,7 @@
 """Tests for check_file_existence decorator."""
 
+import logging
+
 import pytest
 
 from aatoolbox.utils.check_file_existence import check_file_existence
@@ -11,24 +13,38 @@ def downloader(filepath, clobber):
     return "a"
 
 
-def test_fp_exists_no_clobber(tmp_path):
+def test_fp_exists_no_clobber(tmp_path, caplog):
     """Test that filepath returned if Path exists and clobber False."""
-    tmp_path.touch()
+    caplog.set_level(logging.INFO)
     output_filepath = downloader(filepath=tmp_path, clobber=False)
     assert output_filepath == tmp_path
+    assert (
+        f"File {tmp_path} exists and clobber set to "
+        "False, using existing file." in caplog.text
+    )
 
 
-def test_fp_exists_clobber(tmp_path):
+def test_fp_exists_clobber(tmp_path, caplog):
     """Test that function returned if Path exists and clobber True."""
-    tmp_path.touch()
+    caplog.set_level(logging.INFO)
     output_filepath = downloader(filepath=tmp_path, clobber=True)
     assert output_filepath == "a"
+    assert (
+        f"File {tmp_path} exists and clobber set to "
+        "True, overwriting existing file." in caplog.text
+    )
 
 
-def test_fp_not_exists(tmp_path):
+def test_fp_not_exists(tmp_path, caplog):
     """Test that function returned if Path does not exist."""
-    output_filepath = downloader(filepath=tmp_path, clobber=True)
+    caplog.set_level(logging.INFO)
+    path_new = tmp_path / "new_path"
+    output_filepath = downloader(filepath=path_new, clobber=False)
     assert output_filepath == "a"
+    assert (
+        f"File {path_new} does not exist and clobber set to "
+        "False, downloading new file." in caplog.text
+    )
 
 
 def test_key_error(tmp_path):


### PR DESCRIPTION
Simple addressing of #131. As well, noticed that `tmp_path` was not used correctly in the testing module (by default that path exists even without `tmp_path.touch()`), so fixed the testing framework and tested that the logging works correctly.