### PR TITLE
Update COD AB config file customization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Added
 - Module for downloading and processing GloFAS data
 - Module for downloading and processing USGS NDVI data
 - Utilities to streamline use of strings for dates across modules
+- COD AB configuration now has an ``admin{level}_name`` custom
+  layer name parameter
 
 Changed
 ~~~~~~~
@@ -29,6 +31,7 @@ Fixed
 
 - The check in ``DataSource`` for the required configuration file
   section now also checks if the section is ``None``
+- All available admin levels for DRC and Ethiopia are now accessible
 
 [0.4.1] - 2022-05-10
 --------------------

--- a/docs/source/datasources/codab.rst
+++ b/docs/source/datasources/codab.rst
@@ -78,6 +78,7 @@ should be setup as follows:
       hdx_dataset_name: npl_admbnda_nd_20201117_SHP.zip
       layer_base_name: npl_admbnda_adm{admin_level}_nd_20201117.shp
       admin_level_max: 2
+      admin2_name: npl_admbnda_adm2_nd.shp
       custom_layer_names:
         - npl_admbnda_districts_nd_20201117
 
@@ -96,8 +97,13 @@ In the case of Nepal, the layers have the names ``npl_admbnda_adm0_nd_20201117.s
 ``npl_admbnda_adm1_nd_20201117.shp``, and ``npl_admbnda_adm2_nd_20201117.shp``
 
 ``admin_level_max``: The maximum admin level available in the layers. In the case of Nepal,
-the layer level numbers range from 0 to 2, so the maximum should be 2.
+the layer level numbers range from 0 to 2, so the maximum should be 2. In general the
+maximum admin level should not exceed 4.
 
-``custom_layer_name``: A place to list any other layers that don't correspond to the
+``admin{level}_name``: An optional parameter for any admin level (``level`` can range from 0 to 4)
+whose layer names do not match the ``layer_base_name`` pattern. This example for Nepal
+is contrived, but this issue does exist for COD ABs from countries such as Ethiopia and DRC.
+
+``custom_layer_name``: An optional place to list any other layers that don't correspond to the
 admin level format specified above. In the case of Nepal, there is a layer for districts
 with the name ``npl_admbnda_districts_nd_20201117``.

--- a/src/aatoolbox/config/countries/cod.yaml
+++ b/src/aatoolbox/config/countries/cod.yaml
@@ -3,9 +3,7 @@ codab:
   hdx_dataset_name: cod_admbnda_rgc_itos_20190911_SHP.zip
   layer_base_name: cod_admbnda_adm{admin_level}_rgc_itos_20190911.shp
   admin_level_max: 1
-  # this is the name of the adm2 layer
-  custom_layer_names:
-    - cod_admbnda_adm2_rgc_20190911.shp
+  admin2_name: cod_admbnda_adm2_rgc_20190911.shp
 fewsnet:
   region_name: southern-africa
 glofas:

--- a/src/aatoolbox/config/countries/eth.yaml
+++ b/src/aatoolbox/config/countries/eth.yaml
@@ -2,7 +2,8 @@ iso3: eth
 codab:
   hdx_dataset_name: ETH Administrative Divisions Shapefiles.zip
   layer_base_name: eth_admbnda_adm{admin_level}_csa_bofed_20201008.shp
-  admin_level_max: 2
+  admin_level_max: 3
+  admin0_name: eth_admbnda_adm0_csa_bofedb_itos_2021
 fewsnet:
   region_name: east-africa
 glofas:

--- a/src/aatoolbox/config/countries/npl.yaml
+++ b/src/aatoolbox/config/countries/npl.yaml
@@ -3,6 +3,7 @@ codab:
   hdx_dataset_name: npl_admbnda_nd_20201117_SHP.zip
   layer_base_name: npl_admbnda_adm{admin_level}_nd_20201117.shp
   admin_level_max: 2
+  # Nepal also has districts that don't fall into a particular admin level
   custom_layer_names:
     - npl_admbnda_districts_nd_20201117
 glofas:

--- a/src/aatoolbox/config/countryconfig.py
+++ b/src/aatoolbox/config/countryconfig.py
@@ -20,7 +20,11 @@ class CodABConfig(BaseModel):
         change by a single custom_layer_number depending on the level. Should
         contain {admin_level} in place of the custom_layer_number.
     admin_level_max: int
-        The maximum admin level available in the shapefile.
+         The maximum admin level available in the shapefile, cannot be
+         greater than 4
+    admin{level}_name: str, optional
+        The names of any admin level layers that do not conform to the
+        layer_base_name pattern, where {level} ranges from 0 to 4
     custom_layer_names: list, optional
         Any additional layer names that don't fit into the admin level paradigm
     """
@@ -28,16 +32,42 @@ class CodABConfig(BaseModel):
     hdx_dataset_name: str
     layer_base_name: str
     admin_level_max: int
+    admin0_name: Optional[str]
+    admin1_name: Optional[str]
+    admin2_name: Optional[str]
+    admin3_name: Optional[str]
+    admin4_name: Optional[str]
     custom_layer_names: Optional[list]
 
     @validator("layer_base_name")
     def _validate_layer_base_name(cls, layer_base_name):
+        """Ensure that the layer basename contains {admin_level}."""
         if "{admin_level}" not in layer_base_name:
             raise ValueError(
-                "The layer base name must contain "
-                "an {admin_level} placeholder."
+                "In the COD AB section of the country configuration file, "
+                "layer_base_name must contain an {admin_level} placeholder."
             )
         return layer_base_name
+
+    @validator("admin_level_max")
+    def _validate_admin_level_max(cls, admin_level_max):
+        """Ensure that admin_level_max is between 0 and 4."""
+        if not 0 <= admin_level_max <= 4:
+            raise ValueError(
+                "In the COD AB section of the country configuration file, "
+                "admin_level_max must be between 0 and 4."
+            )
+        return admin_level_max
+
+    @root_validator(pre=False, skip_on_failure=True)
+    def _set_admin_levels(cls, values) -> dict:
+        """Set admin levels names using layer base name."""
+        for admin_level in range(values["admin_level_max"] + 1):
+            if values.get(f"admin{admin_level}_name", None) is None:
+                values[f"admin{admin_level}_name"] = values[
+                    "layer_base_name"
+                ].format(admin_level=admin_level)
+        return values
 
 
 class FewsNetConfig(BaseModel):
@@ -89,7 +119,7 @@ class ReportingPoints(BaseModel):
     lat: float
 
 
-class Glofas(BaseModel):
+class GlofasConfig(BaseModel):
     """GloFAS configuration."""
 
     reporting_points: List[ReportingPoints]
@@ -138,16 +168,31 @@ class UsgsNdviConfig(BaseModel):
 
 
 class CountryConfig(BaseModel):
-    """Country configuration."""
+    """Country configuration.
+
+    Parameters
+    ----------
+    iso3 : str
+        Country ISO3, must be exactly 3 letters long
+    codab: CodABConfig, optional
+        Configuration object for COD AB
+    fewsnet: FewsNetConfig, optional
+        Configuration object for FEWS NET
+    glofas: GlofasConfig, optional
+        Configuration object for GloFAS
+    usgs_ndvi: UsgsNdviConfig, optional
+        Configuration object for USGS NDVI
+    """
 
     iso3: str
     codab: Optional[CodABConfig]
     fewsnet: Optional[FewsNetConfig]
-    glofas: Optional[Glofas]
+    glofas: Optional[GlofasConfig]
     usgs_ndvi: Optional[UsgsNdviConfig]
 
     @validator("iso3")
     def _validate_iso3(cls, iso3):
+        """Ensure ISO3 is length three and alphabet chars only."""
         return _validate_iso3(iso3)
 
 
@@ -196,6 +241,7 @@ def create_custom_country_config(filepath: Union[str, Path]) -> CountryConfig:
 
 
 def _validate_iso3(iso3: str):
+    """Ensure ISO3 is length three and alphabet chars only."""
     if len(iso3) != 3 or not str.isalpha(iso3):
         raise ValueError("ISO3 must be a three letter string.")
     return iso3.lower()

--- a/src/aatoolbox/datasources/codab/codab.py
+++ b/src/aatoolbox/datasources/codab/codab.py
@@ -108,8 +108,8 @@ class CodAB(DataSource):
                 f"config file"
             )
         return self._load_admin_layer(
-            layer_name=self._datasource_config.layer_base_name.format(
-                admin_level=admin_level
+            layer_name=getattr(
+                self._datasource_config, f"admin{admin_level}_name"
             )
         )
 

--- a/tests/datasources/fake_config.yaml
+++ b/tests/datasources/fake_config.yaml
@@ -3,6 +3,7 @@ codab:
   hdx_dataset_name: fake_hdx_dataset_name
   layer_base_name: fake_layer_base_name_level{admin_level}
   admin_level_max: 2
+  admin2_name: admin2_custom_name
 fewsnet:
   region_name: east-africa
 glofas:

--- a/tests/datasources/test_codab.py
+++ b/tests/datasources/test_codab.py
@@ -39,11 +39,20 @@ def test_codab_load_admin_level(
 ):
     """Test that load_codab retrieves expected file and layer name."""
     codab = CodAB(country_config=mock_country_config)
-    admin_level = 2
-    expected_layer_name = mock_country_config.codab.layer_base_name.format(
-        admin_level=admin_level
+
+    # First checking layer_base_name
+    expected_layer_name = "fake_layer_base_name_level1"
+    codab.load(admin_level=1)
+
+    gpd_read_file.assert_called_with(
+        f"zip://{mock_aa_data_dir}/public/raw/{mock_country_config.iso3}/"
+        f"{DATASOURCE_BASE_DIR}/{mock_country_config.iso3}_"
+        f"{DATASOURCE_BASE_DIR}.shp.zip/{expected_layer_name}"
     )
-    codab.load(admin_level=admin_level)
+
+    # Then checking custom name
+    expected_layer_name = "admin2_custom_name"
+    codab.load(admin_level=2)
 
     gpd_read_file.assert_called_with(
         f"zip://{mock_aa_data_dir}/public/raw/{mock_country_config.iso3}/"

--- a/tests/test_country_config.py
+++ b/tests/test_country_config.py
@@ -95,34 +95,6 @@ def test_codab_validate_layer_base_name(mock_parse_yaml):
 
 
 def test_codab_validate_admin_level_max(mock_parse_yaml):
-    """Test that layer basename requires correct placeholder."""
-    config_base = {
-        "iso3": "abc",
-        "codab": {
-            "hdx_dataset_name": "fake_dataset_name",
-            "layer_base_name": "layer_base_name_{admin_level}",
-            "admin_level_max": 1,
-        },
-    }
-    config_correct = copy.deepcopy(config_base)
-    config_incorrect_a = copy.deepcopy(config_base)
-    config_incorrect_a["codab"]["admin_level_max"] = -1
-    config_incorrect_b = copy.deepcopy(config_base)
-    config_incorrect_b["codab"]["admin_level_max"] = 5
-    mock_parse_yaml(
-        output_list=[config_correct, config_incorrect_a, config_incorrect_b]
-    )
-    # Check that correct config runs without issue
-    create_country_config(iso3="abc")
-    # Check that incorrect config raises error for config incorrect a
-    with pytest.raises(ValueError):
-        create_country_config(iso3="abc")
-    # Check that incorrect config raises error for config incorrect b
-    with pytest.raises(ValueError):
-        create_country_config(iso3="abc")
-
-
-def test_codab_admin_level_max(mock_parse_yaml):
     """Test that admin level can only be between 0 and 4."""
     config_base = {
         "iso3": "abc",

--- a/tests/test_country_config.py
+++ b/tests/test_country_config.py
@@ -150,23 +150,6 @@ def test_codab_admin_level_max(mock_parse_yaml):
         create_country_config(iso3="abc")
 
 
-def test_codab_admin_level_names(mock_parse_yaml):
-    """Test that admin level names are set correctly."""
-    config_base = {
-        "iso3": "abc",
-        "codab": {
-            "hdx_dataset_name": "fake_dataset_name",
-            "layer_base_name": "layer_base_name_{admin_level}",
-            "admin_level_max": 1,
-            "admin0_name": "custom_admin0_name",
-        },
-    }
-    mock_parse_yaml(output_list=[config_base])
-    country_config = create_country_config(iso3="abc")
-    assert country_config.codab.admin0_name == "custom_admin0_name"
-    assert country_config.codab.admin1_name == "layer_base_name_1"
-
-
 def test_fewsnet_validate_region_name(mock_parse_yaml):
     """Test that fewsnet requires correct region name."""
     config_base = {

--- a/tests/test_country_config.py
+++ b/tests/test_country_config.py
@@ -72,7 +72,7 @@ def test_uppercase_config_iso3(mock_parse_yaml):
     assert country_config.iso3 == "abc"
 
 
-def test_validate_codab_layer_base_name(mock_parse_yaml):
+def test_codab_validate_layer_base_name(mock_parse_yaml):
     """Test that layer basename requires correct placeholder."""
     config_base = {
         "iso3": "abc",
@@ -94,7 +94,80 @@ def test_validate_codab_layer_base_name(mock_parse_yaml):
         create_country_config(iso3="abc")
 
 
-def test_validate_fewsnet_region_name(mock_parse_yaml):
+def test_codab_validate_admin_level_max(mock_parse_yaml):
+    """Test that layer basename requires correct placeholder."""
+    config_base = {
+        "iso3": "abc",
+        "codab": {
+            "hdx_dataset_name": "fake_dataset_name",
+            "layer_base_name": "layer_base_name_{admin_level}",
+            "admin_level_max": 1,
+        },
+    }
+    config_correct = copy.deepcopy(config_base)
+    config_incorrect_a = copy.deepcopy(config_base)
+    config_incorrect_a["codab"]["admin_level_max"] = -1
+    config_incorrect_b = copy.deepcopy(config_base)
+    config_incorrect_b["codab"]["admin_level_max"] = 5
+    mock_parse_yaml(
+        output_list=[config_correct, config_incorrect_a, config_incorrect_b]
+    )
+    # Check that correct config runs without issue
+    create_country_config(iso3="abc")
+    # Check that incorrect config raises error for config incorrect a
+    with pytest.raises(ValueError):
+        create_country_config(iso3="abc")
+    # Check that incorrect config raises error for config incorrect b
+    with pytest.raises(ValueError):
+        create_country_config(iso3="abc")
+
+
+def test_codab_admin_level_max(mock_parse_yaml):
+    """Test that admin level can only be between 0 and 4."""
+    config_base = {
+        "iso3": "abc",
+        "codab": {
+            "hdx_dataset_name": "fake_dataset_name",
+            "layer_base_name": "layer_base_name_{admin_level}",
+            "admin_level_max": 1,
+        },
+    }
+    config_correct = copy.deepcopy(config_base)
+    config_incorrect_a = copy.deepcopy(config_base)
+    config_incorrect_a["codab"]["admin_level_max"] = -1
+    config_incorrect_b = copy.deepcopy(config_base)
+    config_incorrect_b["codab"]["admin_level_max"] = 5
+    mock_parse_yaml(
+        output_list=[config_correct, config_incorrect_a, config_incorrect_b]
+    )
+    # Check that correct config runs without issue
+    create_country_config(iso3="abc")
+    # Check that incorrect config raises error for config incorrect a
+    with pytest.raises(ValueError):
+        create_country_config(iso3="abc")
+    # Check that incorrect config raises error for config incorrect b
+    with pytest.raises(ValueError):
+        create_country_config(iso3="abc")
+
+
+def test_codab_admin_level_names(mock_parse_yaml):
+    """Test that admin level names are set correctly."""
+    config_base = {
+        "iso3": "abc",
+        "codab": {
+            "hdx_dataset_name": "fake_dataset_name",
+            "layer_base_name": "layer_base_name_{admin_level}",
+            "admin_level_max": 1,
+            "admin0_name": "custom_admin0_name",
+        },
+    }
+    mock_parse_yaml(output_list=[config_base])
+    country_config = create_country_config(iso3="abc")
+    assert country_config.codab.admin0_name == "custom_admin0_name"
+    assert country_config.codab.admin1_name == "layer_base_name_1"
+
+
+def test_fewsnet_validate_region_name(mock_parse_yaml):
     """Test that fewsnet requires correct region name."""
     config_base = {
         "iso3": "abc",


### PR DESCRIPTION
Addresses #147, and supersedes #125. 

Make it possible to specify custom COD AB layer names in the configuration file.