### PR TITLE
Fix IRI auth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 
 - The check in ``DataSource`` for the required configuration file
   section now also checks if the section is ``None``
+- IRI download method now checks request headers to verify authentication
 
 [0.4.1] - 2022-05-10
 --------------------

--- a/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
+++ b/src/aatoolbox/datasources/iri/iri_seasonal_forecast.py
@@ -198,11 +198,11 @@ class _IriForecast(DataSource):
         )
         if response.headers["Content-Type"] != "application/x-netcdf":
             msg = (
-                f"The request returned headers indicating that there was "
-                f"an issue with the authentication. Please check the "
+                f"The request returned headers indicating that the expected "
+                f"file type was not returned. In some cases th  is may be due "
+                f"to an issue with the authentication. Please check the "
                 f"validity of the authentication key found in your "
-                f"{_IRI_AUTH} environment variable and try to download "
-                f"again."
+                f"{_IRI_AUTH} environment variable and try again."
             )
             raise requests.RequestException(msg)
         with open(filepath, "wb") as out_file:

--- a/tests/datasources/test_iri.py
+++ b/tests/datasources/test_iri.py
@@ -2,6 +2,7 @@
 import cftime
 import numpy as np
 import pytest
+import requests
 import xarray as xr
 from xarray.coding.cftimeindex import CFTimeIndex
 
@@ -103,6 +104,24 @@ def test_download_call_dominant(
         f"abc_iri_forecast_seasonal_"
         f"precipitation_tercile_dominant_Np6Sp3Ep2Wm3.nc"
     )
+
+
+@pytest.fixture
+def mock_requests(mocker):
+    """Mock requests in the download function."""
+    requests_mock = mocker.patch(
+        "aatoolbox.datasources.iri.iri_seasonal_forecast.requests.get"
+    )
+    return requests_mock
+
+
+def test_download_wrong_auth(
+    mock_iri, mock_requests, mock_aa_data_dir, mock_country_config
+):
+    """Check that wrong download headers raise an error."""
+    iri = mock_iri(prob_forecast=True)
+    with pytest.raises(requests.RequestException):
+        iri.download()
 
 
 def test_process(mocker, mock_iri, mock_aa_data_dir, mock_country_config):

--- a/tests/datasources/test_iri.py
+++ b/tests/datasources/test_iri.py
@@ -112,6 +112,11 @@ def mock_requests(mocker):
     requests_mock = mocker.patch(
         "aatoolbox.datasources.iri.iri_seasonal_forecast.requests.get"
     )
+    mocker.patch.dict(
+        "aatoolbox.datasources.iri.iri_seasonal_forecast.os.environ",
+        {"IRI_AUTH": FAKE_IRI_AUTH},
+    )
+
     return requests_mock
 
 


### PR DESCRIPTION
Addresses #149. Check request headers to verify IRI auth, instead of downloading broken files. 